### PR TITLE
Fix few typos

### DIFF
--- a/content/doc/basics/project-workflow.md
+++ b/content/doc/basics/project-workflow.md
@@ -8,7 +8,7 @@ Let's dive a little more into how we envision that each project you start might 
 
 ## Generic Guidelines
 
-Each project is unique, but we still like to provide these generic guidelines that will give you an idea what you
+Each project is unique but we still like to provide these generic guidelines that will give you an idea what you can do.
 
 ### Phase #1: Project Planning
 
@@ -56,7 +56,7 @@ If your project consists of the **BigClown**-only hardware components, this part
 
 However, if you need to hookup and/or solder your own circuitry or any 3rd party breakout board, we did not put any obstacle in your way. For such purposes, you can find the prototyping area on the **Battery Module** or **Base Module**.
 
-{{% note "warning" %}}Simple 2-wire interfaces like thermistors, external inputs or voltage outputs can be connected using **Sensor Module** featuring 2 channels and flexible weak/strong pull-up configuration.{{% /note %}}
+{{% note "warning" %}}Simple 1-Wire interfaces like thermistors, external inputs or voltage outputs can be connected using **Sensor Module** featuring 2 channels and flexible weak/strong pull-up configuration.{{% /note %}}
 
 ### Phase #5: Playground Bootstrap
 
@@ -76,7 +76,7 @@ This **BigClown Playground** includes:
 
 {{% note "info" %}}More information can be found in the document [**Playground Setup**]({{< relref "doc/tutorials/playground-setup.md" >}}) and [**Playground Starter**]({{< relref "doc/tutorials/playground-starter.md" >}}).{{% /note %}}
 
-{{% note "success" %}}If you prefer the more technical approach and want to write things from scratch, there is no problem whatsoever to dive deep to **Python**, **Node.js** or any other environment  you are comfortable with.{{% /note %}}
+{{% note "success" %}}If you prefer the more technical approach and want to write things from scratch, there is no problem whatsoever to dive deep to **Python**, **Node.js** or any other environment you are comfortable with.{{% /note %}}
 
 ### Phase #6: Radio Pairing
 
@@ -120,7 +120,7 @@ The integration guides are discussed in the **Integrations** section of this doc
 
 It is the right approach to have MQTT topics and responses properly described so you can tweak your project, extend it or integrate it easily anytime from any development environment.
 
-Remember, the MQTT asynchronous approach allows you to build the whole architecture of microservices.
+Remember, the MQTT's asynchronous approach allows you to build the whole architecture of microservices.
 
 {{% note "info" %}}More information can be found in the document [**MQTT Protocol**]({{< relref "doc/interfaces/mqtt-protocol.md" >}}).{{% /note %}}
 

--- a/content/doc/basics/quick-tutorial.md
+++ b/content/doc/basics/quick-tutorial.md
@@ -45,7 +45,7 @@ After the **Raspberry Pi** boots up you should be able to find it at address `hu
 
 {{< note "warning" >}}If the Raspberry Pi is not visible on the network, there's something wrong with your network setup or your system doesn't support **mDNS** and you have to find the IP address of the **Raspberry Pi** in your router's **DHCP** configuration.{{< /note >}}
 
-Please log on the Raspberry Pi shell by typing `ssh pi@hub.localhost` command or use the Windows program **PuTTY**.
+Please log on the Raspberry Pi shell by typing `ssh pi@hub.local` command or use the Windows program **PuTTY**.
 
 ## Firmware Upload
 

--- a/content/doc/firmware/how-to-accelerometer.md
+++ b/content/doc/firmware/how-to-accelerometer.md
@@ -17,7 +17,7 @@ Basically you have **two options how to use the accelerometer - continuous measu
 ## Continuous Measurement
 This can be achieved by setting the update interval in your code with function `bc_lis2dh12_set_update_interval`, which takes pointer to instantiated accelerometer and time before measurements in milliseconds as parameters.
 
-You also have to instantiate a struct `bc_lis2dh12_result_g_t` to store results of measurements. Those values can be retrieved by calling `bc_lis2dh12_get_result_g` function. In simple example bellow, we measure exact values of acceleration in g every second and send them over USB.
+You also have to instantiate a struct `bc_lis2dh12_result_g_t` to store results of measurements. Those values can be retrieved by calling `bc_lis2dh12_get_result_g` function. In simple example below, we measure exact values of acceleration in g every second and send them over USB.
 
 ```
 #include <bcl.h>
@@ -27,12 +27,6 @@ bc_led_t led;
 
 bc_lis2dh12_t a;
 bc_lis2dh12_result_g_t a_result;
-
-void disableLed(void* params)
-{
-    (void) params;
-    bc_led_set_mode(&led, BC_LED_MODE_OFF);
-}
 
 void lis2_event_handler(bc_lis2dh12_t *self, bc_lis2dh12_event_t event, void *event_param)
 {
@@ -67,9 +61,9 @@ You can set conditions for the alarm in struct [*bc_lis2dh12_alarm_t*](http://sd
 
 When the accelerometer checks these settings it uses logical AND operation (so every set condition needs to occur for the alarm to be triggered).
 
-In example bellow, we set the alarm to be triggered when core module is moved in direction of X-axis with acceleration > 1g. When triggered, integrated red LED will switch on for one second.
+In the example below, we set the alarm to be triggered when core module is moved in direction of X-axis with acceleration > 1g. When triggered, integrated red LED will switch on for one second.
 
-After flashing, try to move your Core module very slowly. It will do nothing in any direction. Then try to move it quickly up and down - once again nothing happens, because this movement is in Z-axis. No try to make a quick move in X-axis and the LED should light up.
+After flashing, try to move your Core module very slowly. It will do nothing in any direction. Then try to move it quickly up and down - once again nothing happens, because this movement is in Z-axis. Now try to make a quick move in X-axis and the LED should light up.
 
 
 ```


### PR DESCRIPTION
Hi guys,

here's the list of what I've fixed:
- quick-tutorial.md:
  - small fix for ssh command
- how-to-accelerometer.md:
  - fix typos: no -> now, bellow -> below
  - remove unused function from the first example
- project-workflow.md:
  - fix few typos and omissions

Hope it helps :-)